### PR TITLE
Task: Windows - Automate CMake build for including ASIO support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,3 +7,4 @@ in the README, we are considering a mix of GPL3 and MIT licensing for SC3.
 Claes Johanson (@kurasu / original author)
 Paul Walker (@baconpaul)
 Andrew Shakinovsky (@rudeog)
+James Alan Nguyen (@djtubig-malicex)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,10 @@ elseif (UNIX AND NOT APPLE)
     set(OS_LINK_LIBRARIES
             )
 else ()
+    execute_process(COMMAND powershell
+            -ExecutionPolicy Bypass
+            -File "scripts/win_dl_asiosdk.ps1"
+            )
     set(OS_COMPILE_OPTIONS
             /wd4244   # convert float from double
             /wd4305   # truncate from double to float
@@ -256,6 +260,7 @@ target_compile_definitions(ShortCircuit3 PUBLIC
 
         JUCE_ALSA=1
         JUCE_JACK=1
+        JUCE_ASIO=1
         )
 target_link_libraries(ShortCircuit3 PRIVATE
         ShortCircuit3-Binary

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,8 +260,16 @@ target_compile_definitions(ShortCircuit3 PUBLIC
 
         JUCE_ALSA=1
         JUCE_JACK=1
+        )
+# ASIO SDK is only for MS Windows.
+if (NOT APPLE AND NOT UNIX)
+    target_compile_definitions(ShortCircuit3 PUBLIC
         JUCE_ASIO=1
         )
+    target_include_directories(ShortCircuit3 PUBLIC
+       "libs/asiosdk/common"
+       )
+endif()
 target_link_libraries(ShortCircuit3 PRIVATE
         ShortCircuit3-Binary
         shortcircuit-core

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ add_custom_target(git-info BYPRODUCTS ${CMAKE_BINARY_DIR}/geninclude/version.cpp
 add_subdirectory(libs/JUCE)
 
 # Optional variables
-set(SC3_INCLUDE_ASIO_SUPPORT FALSE)
+set(SC3_INCLUDE_ASIO_SUPPORT TRUE)
 
 # Platform Specific Compile Settings
 if (APPLE)
@@ -270,7 +270,7 @@ target_compile_definitions(ShortCircuit3 PUBLIC
         JUCE_JACK=1
         )
 # ASIO SDK is only for MS Windows.
-if (NOT APPLE AND NOT UNIX AND SC3_SET_INCLUDE_ASIO_SUPPORT)
+if (NOT APPLE AND NOT UNIX AND SC3_INCLUDE_ASIO_SUPPORT)
     target_compile_definitions(ShortCircuit3 PUBLIC
         JUCE_ASIO=1
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,9 @@ add_custom_target(git-info BYPRODUCTS ${CMAKE_BINARY_DIR}/geninclude/version.cpp
 # And include JUCE
 add_subdirectory(libs/JUCE)
 
+# Optional variables
+set(SC3_INCLUDE_ASIO_SUPPORT FALSE)
+
 # Platform Specific Compile Settings
 if (APPLE)
     set(OS_COMPILE_OPTIONS
@@ -86,10 +89,12 @@ elseif (UNIX AND NOT APPLE)
     set(OS_LINK_LIBRARIES
             )
 else ()
-    execute_process(COMMAND powershell
-            -ExecutionPolicy Bypass
-            -File "scripts/win_dl_asiosdk.ps1"
-            )
+    if (SC3_INCLUDE_ASIO_SUPPORT)
+        execute_process(COMMAND powershell
+                -ExecutionPolicy Bypass
+                -File "scripts/win_dl_asiosdk.ps1"
+                )
+    endif()
     set(OS_COMPILE_OPTIONS
             /wd4244   # convert float from double
             /wd4305   # truncate from double to float
@@ -265,7 +270,7 @@ target_compile_definitions(ShortCircuit3 PUBLIC
         JUCE_JACK=1
         )
 # ASIO SDK is only for MS Windows.
-if (NOT APPLE AND NOT UNIX)
+if (NOT APPLE AND NOT UNIX AND SC3_SET_INCLUDE_ASIO_SUPPORT)
     target_compile_definitions(ShortCircuit3 PUBLIC
         JUCE_ASIO=1
         )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ add_custom_target(git-info BYPRODUCTS ${CMAKE_BINARY_DIR}/geninclude/version.cpp
 add_subdirectory(libs/JUCE)
 
 # Optional variables
-set(SC3_INCLUDE_ASIO_SUPPORT TRUE)
+set(SC3_INCLUDE_ASIO_SUPPORT FALSE)
 
 # Platform Specific Compile Settings
 if (APPLE)

--- a/scripts/win_dl_asiosdk.ps1
+++ b/scripts/win_dl_asiosdk.ps1
@@ -27,5 +27,5 @@ if (-not (Test-Path $SDK_LOCATION))
 	Set-Location $LIB_DIR
 	(Get-ChildItem -Filter "asiosdk*")[0] | Rename-Item -NewName { $_.Name -Replace $_.Name, $SDK_DIRNAME }
 } else {
-	Write-Output "--   Steinberg ASIO SDK present in libs."
+	Write-Output "--   Steinberg ASIO SDK present in $SDK_LOCATION."
 }

--- a/scripts/win_dl_asiosdk.ps1
+++ b/scripts/win_dl_asiosdk.ps1
@@ -6,7 +6,7 @@
 # project paths
 $LIB_DIR="libs"
 $SDK_DIRNAME="asiosdk"
-$SDK_LOCATION="libs\$SDK_DIRNAME"
+$SDK_LOCATION="$LIB_DIR\$SDK_DIRNAME"
 
 # download params
 $ASIO_SDK_URL="https://www.steinberg.net/asiosdk"
@@ -23,9 +23,11 @@ if (-not (Test-Path $SDK_LOCATION))
 		Write-Output "--   Found $SDK_DOWNLOAD_FILE from previous download."
 	}
 	Write-Output "--   Extracting to $SDK_LOCATION..."
-	Expand-Archive asiosdk.zip $LIB_DIR
+	Expand-Archive $SDK_DOWNLOAD_FILE $LIB_DIR
 	Set-Location $LIB_DIR
-	(Get-ChildItem -Filter "asiosdk*")[0] | Rename-Item -NewName { $_.Name -Replace $_.Name, $SDK_DIRNAME }
+	
+	# SDK zip has it in a timestamped directory name. This strips it off.
+	(Get-ChildItem -Filter "$SDK_DIRNAME*")[0] | Rename-Item -NewName { $_.Name -Replace $_.Name, $SDK_DIRNAME }
 } else {
 	Write-Output "--   Steinberg ASIO SDK present in $SDK_LOCATION."
 }

--- a/scripts/win_dl_asiosdk.ps1
+++ b/scripts/win_dl_asiosdk.ps1
@@ -1,0 +1,31 @@
+##############################################################################
+## This script will auto-download and unpack the latest Steinberg ASIO SDK. ##
+## Assumes CWD is at the root level (eg: same location as CMakeLists)       ##
+##############################################################################
+
+# project paths
+$LIB_DIR="libs"
+$SDK_DIRNAME="asiosdk"
+$SDK_LOCATION="libs\$SDK_DIRNAME"
+
+# download params
+$ASIO_SDK_URL="https://www.steinberg.net/asiosdk"
+$SDK_DOWNLOAD_FILE="asiosdk.zip"
+
+Write-Output "-- Checking for Steinberg ASIO SDK..."
+if (-not (Test-Path $SDK_LOCATION))
+{
+	if (-not (Test-Path $SDK_DOWNLOAD_FILE))
+	{
+		Write-Output "--   Downloading Steinberg ASIO SDK..."
+		Invoke-WebRequest -Uri $ASIO_SDK_URL -UseBasicParsing -OutFIle $SDK_DOWNLOAD_FILE
+	} else {
+		Write-Output "--   Found $SDK_DOWNLOAD_FILE from previous download."
+	}
+	Write-Output "--   Extracting to $SDK_LOCATION..."
+	Expand-Archive asiosdk.zip $LIB_DIR
+	Set-Location $LIB_DIR
+	(Get-ChildItem -Filter "asiosdk*")[0] | Rename-Item -NewName { $_.Name -Replace $_.Name, $SDK_DIRNAME }
+} else {
+	Write-Output "--   Steinberg ASIO SDK present in libs."
+}


### PR DESCRIPTION
As the title says.
- Utilises Powershell (inbuilt in all major versions of Windows since Windows 7 SP1) to automatically download Steinberg ASIO SDK, extract and include in generated build projects.
- Inclusion of `JUCE_ASIO=1` isolated to Windows build path.

This PR also includes agreement to the CLA as specified in shortcircuit3 source repo.