### PR TITLE
Unregister on Destroy

### DIFF
--- a/wrappers/juce/SC3Editor.cpp
+++ b/wrappers/juce/SC3Editor.cpp
@@ -12,7 +12,6 @@
 #include "SC3Editor.h"
 #include "SC3Processor.h"
 #include "version.h"
-#include "interaction_parameters.h"
 
 #include <unordered_map>
 
@@ -58,26 +57,32 @@ SC3AudioProcessorEditor::SC3AudioProcessorEditor(SC3AudioProcessor &p)
 
     actiondata ad;
     ad.actiontype = vga_openeditor;
-    sendActionToEngine(ad);
+    sendActionInternal(ad);
+
 
     idleTimer = std::make_unique<SC3IdleTimer>(this);
     idleTimer->startTimer(1000 / 30);
 }
 
-void SC3AudioProcessorEditor::sendActionToEngine(const actiondata &ad)
-{
-    audioProcessor.sc3->postEventsFromWrapper(ad);
-}
 
 SC3AudioProcessorEditor::~SC3AudioProcessorEditor() {
     uiStateProxies.clear();
     debugWindow->panel->setEditor(nullptr);
     idleTimer->stopTimer();
-    audioProcessor.mNotify=0;
+    audioProcessor.mNotify=nullptr;
 
     actiondata ad;
     ad.actiontype = vga_closeeditor;
-    sendActionToEngine(ad);
+    sendActionInternal(ad);
+
+    audioProcessor.sc3->unregisterWrapperForEvents(this);
+}
+
+void SC3AudioProcessorEditor::sendActionToEngine(const actiondata &ad) { sendActionInternal(ad); }
+
+void SC3AudioProcessorEditor::sendActionInternal(const actiondata &ad)
+{
+    audioProcessor.sc3->postEventsFromWrapper(ad);
 }
 
 void SC3AudioProcessorEditor::buttonClicked(Button *b)

--- a/wrappers/juce/SC3Editor.h
+++ b/wrappers/juce/SC3Editor.h
@@ -125,6 +125,8 @@ class SC3AudioProcessorEditor : public juce::AudioProcessorEditor,
     SC3AudioProcessor &audioProcessor;
 
   private:
+    void sendActionInternal(const actiondata &ad);
+
     std::unique_ptr<DebugPanelWindow> debugWindow;
     std::unique_ptr<SC3EngineToWrapperQueue<actiondata>> actiondataToUI;
     std::unique_ptr<SC3EngineToWrapperQueue<std::string>> logToUI;


### PR DESCRIPTION
The SC3Editor wasn't unregistering itself as a message target
or log target when destroyed, with deleterious effects.
Reaper mac wouldn't work on a second open for instance.
I also suspect this will cure the savi on startup crash
in #79