### PR TITLE
ASIO Bugfix - audio buffering issue for ultra-low and other sizes not a multiple of 64

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -25,7 +25,6 @@ typedef uint32_t uint32;
 
 const uint32 block_size = 32; // must be a multiple of 4 (SIMD)
 const uint32 block_size_quad = block_size >> 2;
-const uint32 chunk = 4;  // sample copy grain size
 const float inv_block_size = 1.f / float(block_size);
 const float inv_2block_size = 1.f / float(block_size << 1);
 const __m128 inv_block_size_128 = _mm_set1_ps(inv_block_size);

--- a/src/globals.h
+++ b/src/globals.h
@@ -25,6 +25,7 @@ typedef uint32_t uint32;
 
 const uint32 block_size = 32; // must be a multiple of 4 (SIMD)
 const uint32 block_size_quad = block_size >> 2;
+const uint32 chunk = 4;  // sample copy grain size
 const float inv_block_size = 1.f / float(block_size);
 const float inv_2block_size = 1.f / float(block_size << 1);
 const __m128 inv_block_size_128 = _mm_set1_ps(inv_block_size);

--- a/src/globals.h
+++ b/src/globals.h
@@ -23,7 +23,7 @@
 
 typedef uint32_t uint32;
 
-const uint32 block_size = 64; // must be a multiple of 4 (SIMD)
+const uint32 block_size = 32; // must be a multiple of 4 (SIMD)
 const uint32 block_size_quad = block_size >> 2;
 const float inv_block_size = 1.f / float(block_size);
 const float inv_2block_size = 1.f / float(block_size << 1);

--- a/tests/format_tests.cpp
+++ b/tests/format_tests.cpp
@@ -44,11 +44,11 @@ TEST_CASE("Simple SF2 Load", "[formats]")
         for (auto n : notes)
         {
             double rms = 0;
-            for (int i = 0; i < 150; ++i)
+            for (int i = 0; i < 300; ++i)
             {
-                if (i == 30)
+                if (i == 60)
                     sc3->PlayNote(0, n, 120);
-                if (i == 70)
+                if (i == 140)
                     sc3->ReleaseNote(0, n, 0);
 
                 sc3->process_audio();
@@ -61,9 +61,9 @@ TEST_CASE("Simple SF2 Load", "[formats]")
             rms = sqrt(rms);
             rmses.push_back(rms);
         }
-        REQUIRE(rmses[0] == Approx(15.14437).margin(1e-3));
-        REQUIRE(rmses[1] == Approx(18.16663).margin(1e-3));
-        REQUIRE(rmses[2] == Approx(18.72027).margin(1e-3));
+        REQUIRE(rmses[0] == Approx(19.86253).margin(1e-3));
+        REQUIRE(rmses[1] == Approx(21.01420).margin(1e-3));
+        REQUIRE(rmses[2] == Approx(20.87521).margin(1e-3));
     }
 }
 
@@ -83,11 +83,11 @@ TEST_CASE("Simple WAV Load", "[formats]")
 
         double rms = 0;
         int n = 36;
-        for (int i = 0; i < 100; ++i)
+        for (int i = 0; i < 200; ++i)
         {
-            if (i == 30)
+            if (i == 60)
                 sc3->PlayNote(0, n, 120);
-            if (i == 70)
+            if (i == 140)
                 sc3->ReleaseNote(0, n, 0);
 
             sc3->process_audio();
@@ -98,7 +98,7 @@ TEST_CASE("Simple WAV Load", "[formats]")
             }
         }
         rms = sqrt(rms);
-        REQUIRE(rms == Approx(2.2468728).margin(1e-4));
+        REQUIRE(rms == Approx(5.9624592896).margin(1e-4));
     }
 }
 

--- a/tests/format_tests.cpp
+++ b/tests/format_tests.cpp
@@ -61,9 +61,9 @@ TEST_CASE("Simple SF2 Load", "[formats]")
             rms = sqrt(rms);
             rmses.push_back(rms);
         }
-        REQUIRE(rmses[0] == Approx(19.88632).margin(1e-3));
-        REQUIRE(rmses[1] == Approx(20.96383).margin(1e-3));
-        REQUIRE(rmses[2] == Approx(20.93767).margin(1e-3));
+        REQUIRE(rmses[0] == Approx(15.14437).margin(1e-3));
+        REQUIRE(rmses[1] == Approx(18.16663).margin(1e-3));
+        REQUIRE(rmses[2] == Approx(18.72027).margin(1e-3));
     }
 }
 
@@ -98,7 +98,7 @@ TEST_CASE("Simple WAV Load", "[formats]")
             }
         }
         rms = sqrt(rms);
-        REQUIRE(rms == Approx(6.0266351586).margin(1e-4));
+        REQUIRE(rms == Approx(2.2468728).margin(1e-4));
     }
 }
 

--- a/tests/zone_tests.cpp
+++ b/tests/zone_tests.cpp
@@ -163,7 +163,7 @@ TEST_CASE("Zones from 3 Wavs", "[zones]")
             else
             {
                 INFO("Checking with note " << n);
-                std::vector<float> vals = {16.963544, 14.8987890705, 8.9075824};
+                std::vector<float> vals = {16.964918, 14.899617, 8.906973};
                 REQUIRE(rms == Approx(vals[n - 36]).margin(1e-5));
             }
         }

--- a/tests/zone_tests.cpp
+++ b/tests/zone_tests.cpp
@@ -141,7 +141,7 @@ TEST_CASE("Zones from 3 Wavs", "[zones]")
             double rms = 0;
             for (int i = 0; i < oneSecInBlocks; ++i)
             {
-                if (i == 30)
+                if (i == 60)
                     sc3->PlayNote(0, n, 120);
                 if (i == oneSecInBlocks - 50)
                     sc3->ReleaseNote(0, n, 0);
@@ -153,7 +153,7 @@ TEST_CASE("Zones from 3 Wavs", "[zones]")
                            sc3->output[1][k] * sc3->output[1][k];
                 }
             }
-            for (int i = 0; i < 1000; ++i)
+            for (int i = 0; i < 2000; ++i)
                 sc3->process_audio();
             rms = sqrt(rms);
             if (n < 36 || n > 38)
@@ -163,7 +163,7 @@ TEST_CASE("Zones from 3 Wavs", "[zones]")
             else
             {
                 INFO("Checking with note " << n);
-                std::vector<float> vals = {16.964918, 14.899617, 8.906973};
+                std::vector<float> vals = {16.964388, 14.899617, 8.906973};
                 REQUIRE(rms == Approx(vals[n - 36]).margin(1e-5));
             }
         }

--- a/wrappers/juce/SC3Processor.cpp
+++ b/wrappers/juce/SC3Processor.cpp
@@ -14,7 +14,7 @@ void *hInstance = 0;
 
 //==============================================================================
 SC3AudioProcessor::SC3AudioProcessor()
-    : AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)), mNotify(0)
+    : AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)), mNotify(0), blockpos(0)
 {
     // This is a good place for VS mem leak debugging:
     // _CrtSetBreakAlloc(<id>);
@@ -107,15 +107,21 @@ void SC3AudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
 
     auto mainInputOutput = getBusBuffer(buffer, false, 0);
 
-    for (int outPos = 0; outPos < buffer.getNumSamples(); outPos += block_size)
+    for (int i = 0; i < buffer.getNumSamples(); i += chunk)
     {
-        auto outL = mainInputOutput.getWritePointer(0, outPos);
-        auto outR = mainInputOutput.getWritePointer(1, outPos);
+        auto outL = mainInputOutput.getWritePointer(0, i);
+        auto outR = mainInputOutput.getWritePointer(1, i);
 
-        sc3->process_audio();
+        if (blockpos == 0)
+            sc3->process_audio();
+        
+        memcpy(outL, &((sc3->output[0])[blockpos]), chunk * sizeof(float));
+        memcpy(outR, &((sc3->output[1])[blockpos]), chunk * sizeof(float));
 
-        memcpy(outL, &(sc3->output[0]), block_size * sizeof(float));
-        memcpy(outR, &(sc3->output[1]), block_size * sizeof(float));
+        blockpos += chunk;
+
+        if (blockpos >= block_size)
+            blockpos = 0;
     }
 }
 

--- a/wrappers/juce/SC3Processor.cpp
+++ b/wrappers/juce/SC3Processor.cpp
@@ -115,8 +115,8 @@ void SC3AudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
         if (blockpos == 0)
             sc3->process_audio();
         
-        memcpy(outL, &((sc3->output[0])[blockpos]), chunk * sizeof(float));
-        memcpy(outR, &((sc3->output[1])[blockpos]), chunk * sizeof(float));
+        memcpy(outL, &(sc3->output[0][blockpos]), chunk * sizeof(float));
+        memcpy(outR, &(sc3->output[1][blockpos]), chunk * sizeof(float));
 
         blockpos += chunk;
 

--- a/wrappers/juce/SC3Processor.cpp
+++ b/wrappers/juce/SC3Processor.cpp
@@ -14,7 +14,8 @@ void *hInstance = 0;
 
 //==============================================================================
 SC3AudioProcessor::SC3AudioProcessor()
-    : AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)), mNotify(0), blockpos(0)
+    : AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)),
+      mNotify(0), blockPos(0)
 {
     // This is a good place for VS mem leak debugging:
     // _CrtSetBreakAlloc(<id>);
@@ -107,21 +108,21 @@ void SC3AudioProcessor::processBlock(juce::AudioBuffer<float> &buffer,
 
     auto mainInputOutput = getBusBuffer(buffer, false, 0);
 
-    for (int i = 0; i < buffer.getNumSamples(); i += chunk)
+    for (int i = 0; i < buffer.getNumSamples(); i += BUFFER_COPY_CHUNK)
     {
         auto outL = mainInputOutput.getWritePointer(0, i);
         auto outR = mainInputOutput.getWritePointer(1, i);
 
-        if (blockpos == 0)
+        if (blockPos == 0)
             sc3->process_audio();
         
-        memcpy(outL, &(sc3->output[0][blockpos]), chunk * sizeof(float));
-        memcpy(outR, &(sc3->output[1][blockpos]), chunk * sizeof(float));
+        memcpy(outL, &(sc3->output[0][blockPos]), BUFFER_COPY_CHUNK * sizeof(float));
+        memcpy(outR, &(sc3->output[1][blockPos]), BUFFER_COPY_CHUNK * sizeof(float));
 
-        blockpos += chunk;
+        blockPos += BUFFER_COPY_CHUNK;
 
-        if (blockpos >= block_size)
-            blockpos = 0;
+        if (blockPos >= block_size)
+            blockPos = 0;
     }
 }
 

--- a/wrappers/juce/SC3Processor.h
+++ b/wrappers/juce/SC3Processor.h
@@ -73,7 +73,8 @@ class SC3AudioProcessor : public juce::AudioProcessor
     
 
   private:
-    size_t blockpos;
+    size_t blockPos;
+    static const uint32 BUFFER_COPY_CHUNK = 4; // sample copy grain size
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SC3AudioProcessor)
 };

--- a/wrappers/juce/SC3Processor.h
+++ b/wrappers/juce/SC3Processor.h
@@ -73,6 +73,7 @@ class SC3AudioProcessor : public juce::AudioProcessor
     
 
   private:
+    size_t blockpos;
     //==============================================================================
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SC3AudioProcessor)
 };


### PR DESCRIPTION
`SC3Processor` for whatever reason assumed the smallest buffer size you could have is 64 samples.  This is not true when using some ASIO drivers such as Steinberg-Yamaha ASIO  which supports 32 samples. This also means any latency sample sizes not a multiple of 64 samples would result in distorted output.

PR fixes:
- Decrease minimum `block_size` to 32 samples (as per Surge, presently)
- Add `blockPos` variable to treat output buffer as a flushing ring buffer.
- Re-jig `processBlock()` sample copy loop to take in incremental grains of 4 samples.