### PR TITLE
Finalize structure of log -> ui

### DIFF
--- a/wrappers/juce/SC3Editor.h
+++ b/wrappers/juce/SC3Editor.h
@@ -90,7 +90,7 @@ class ZoneKeyboardDisplay;
 class SC3AudioProcessorEditor : public juce::AudioProcessorEditor,
                                 public juce::Button::Listener,
                                 public juce::FileDragAndDropTarget,
-                                public EditorNotify,
+                                public LogDisplayListener,
                                 public sampler::WrapperListener,
                                 public ActionSender
 {
@@ -113,7 +113,7 @@ class SC3AudioProcessorEditor : public juce::AudioProcessorEditor,
     // Fixme - obviously this is done with no thought of threading or anything else
     void refreshSamplerTextViewInThreadUnsafeWay();
 
-    void setLogText(const std::string &txt) override;
+    void handleLogMessage(SC3::Log::Level lev, const std::string &txt) override;
 
     void receiveActionFromProgram(const actiondata &ad) override;
     void sendActionToEngine(const actiondata &ad) override;
@@ -129,7 +129,14 @@ class SC3AudioProcessorEditor : public juce::AudioProcessorEditor,
 
     std::unique_ptr<DebugPanelWindow> debugWindow;
     std::unique_ptr<SC3EngineToWrapperQueue<actiondata>> actiondataToUI;
-    std::unique_ptr<SC3EngineToWrapperQueue<std::string>> logToUI;
+    struct LogTransport
+    {
+        SC3::Log::Level lev = SC3::Log::Level::None;
+        std::string txt = "";
+        LogTransport() = default;
+        LogTransport(SC3::Log::Level l, const std::string &t) : lev(l), txt(t) {}
+    };
+    std::unique_ptr<SC3EngineToWrapperQueue<LogTransport>> logToUI;
     std::unique_ptr<SC3IdleTimer> idleTimer;
 
     std::set<UIStateProxy *> uiStateProxies;

--- a/wrappers/juce/SC3Processor.cpp
+++ b/wrappers/juce/SC3Processor.cpp
@@ -15,12 +15,11 @@ void *hInstance = 0;
 //==============================================================================
 SC3AudioProcessor::SC3AudioProcessor()
     : AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)),
-      mNotify(0), blockPos(0)
+      blockPos(0)
 {
     // This is a good place for VS mem leak debugging:
     // _CrtSetBreakAlloc(<id>);
-    mLogger = std::make_unique<SC3ProcessorLogger>(this);
-    sc3 = std::make_unique<sampler>(nullptr, 2, nullptr, mLogger.get());
+    sc3 = std::make_unique<sampler>(nullptr, 2, nullptr, this);
 }
 
 SC3AudioProcessor::~SC3AudioProcessor() {

--- a/wrappers/juce/SC3Processor.h
+++ b/wrappers/juce/SC3Processor.h
@@ -11,26 +11,19 @@
 #include "sampler.h"
 #include <JuceHeader.h>
 
-class SC3ProcessorLogger;
-// temporary
-// the proper way to do this would probably be with a fifo between processor and editor
-class EditorNotify {
+class LogDisplayListener
+{
   public:
-    virtual void setLogText(const std::string &txt)=0;
+    virtual void handleLogMessage(SC3::Log::Level lev, const std::string &txt) = 0;
 };
-
 
 //==============================================================================
 /**
  */
-class SC3AudioProcessor : public juce::AudioProcessor
+class SC3AudioProcessor : public juce::AudioProcessor, public SC3::Log::LoggingCallback
 {
   
   public:
-  // editor will set and clear this...
-  // shitty i know, but it's temporary
-  EditorNotify *mNotify;
-
     //==============================================================================
     SC3AudioProcessor();
     ~SC3AudioProcessor() override;
@@ -38,6 +31,19 @@ class SC3AudioProcessor : public juce::AudioProcessor
     //==============================================================================
     void prepareToPlay(double sampleRate, int samplesPerBlock) override;
     void releaseResources() override;
+
+    std::unordered_set<LogDisplayListener *> logDispList;
+    void addLogDisplayListener(LogDisplayListener *e) { logDispList.insert(e); }
+    void removeLogDisplayListener(LogDisplayListener *e) { logDispList.erase(e); }
+    SC3::Log::Level getLevel() override { return SC3::Log::Level::Debug; }
+
+    void message(SC3::Log::Level lev, const std::string &msg) override
+    {
+        for (auto l : logDispList)
+        {
+            l->handleLogMessage(lev, msg);
+        }
+    }
 
 #ifndef JucePlugin_PreferredChannelConfigurations
     bool isBusesLayoutSupported(const BusesLayout &layouts) const override;
@@ -68,7 +74,6 @@ class SC3AudioProcessor : public juce::AudioProcessor
     void getStateInformation(juce::MemoryBlock &destData) override;
     void setStateInformation(const void *data, int sizeInBytes) override;
 
-    std::unique_ptr<SC3ProcessorLogger>mLogger; // must destroy before sc3 because flush in logger needs its cb
     std::unique_ptr<sampler> sc3;
     
 
@@ -79,20 +84,3 @@ class SC3AudioProcessor : public juce::AudioProcessor
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SC3AudioProcessor)
 };
 
-class SC3ProcessorLogger : public SC3::Log::LoggingCallback {
-
-    SC3AudioProcessor *mParent;
-    SC3::Log::Level getLevel() override {
-        return SC3::Log::Level::Debug;
-    }
-    void message(SC3::Log::Level lev, const std::string &msg) override {
-        if(mParent->mNotify) {
-          std::string t = SC3::Log::getShortLevelStr(lev);
-          t += msg;
-          mParent->mNotify->setLogText(t);
-        }
-    }
-public:
-    SC3ProcessorLogger(SC3AudioProcessor *p) : mParent(p) {}
-    ~SC3ProcessorLogger() {}
-};


### PR DESCRIPTION
The mNotify thing was a bit temporary, although we had a FIFO queue
already, but restructure it so (1) the processor is the log reciever
not an ancilliary class, (2) the level comes through all the way to
the editor idle as data not text, and (3) everything still works!