### PR TITLE
externalize configuration from sampler object

### DIFF
--- a/src/globals.h
+++ b/src/globals.h
@@ -54,6 +54,12 @@ extern float samplerate;
 extern float samplerate_inv;
 extern float multiplier_freq2omega;
 
+// directory under user's profile where sc3 config file(s) will be sought
+// this should end up being same location that juce stores it's standalone app settings
+// TODO AS for juce wrappers, we may consider migrating to using juce's cross platform 
+// facility for loading/saving. see stochas configSerialization
+const char SC3_CONFIG_DIRECTORY[] = "ShortCircuit3";
+
 #if !WINDOWS
 #include "windows_compat.h"
 #endif

--- a/src/sampler.cpp
+++ b/src/sampler.cpp
@@ -62,35 +62,11 @@ sampler::sampler(EditorClass *editor, int NumOutputs, WrapperClass *effect,
     : mLogger(cb), mNumOutputs(NumOutputs)
 {
     LOGINFO(mLogger) << "SC3 engine " << SC3::Build::FullVersionStr << std::flush;
-
-    // load configuration
-    wchar_t path[1024];
-#if WINDOWS
-    extern void *hInstance;
-    holdengine = false;
-    GetModuleFileNameW((HMODULE)hInstance, path, 1024);
-    wchar_t *end = wcsrchr(path, L'\\');
-    if (end)
-    {
-#ifdef SCPB
-        wcscpy(end, L"\\scpb-conf.xml");
-#else
-        wcscpy(end, L"\\shortcircuitV2-conf.xml");
-#endif
-    }
-    else
-    {
-        wcscpy(path, L"");
-        SC3::Log::logos() << "FIXME: Setup Config" << std::endl;
-    }
-    auto ppath = fs::path(path);
-#else
-#warning Deal with configuration paths.
-    wcscpy(path, L"" );
-    auto ppath = string_to_path("");
-#endif
     conf = new configuration(mLogger);
-    conf->load(ppath);
+
+#if WINDOWS    
+    holdengine = false;
+#endif
 
     mpPreview = new sampler::Preview(&time_data, this);
 
@@ -232,6 +208,16 @@ sampler::~sampler(void)
         free(chunkDataPtr);
     if (dbSampleListDataPtr)
         free(dbSampleListDataPtr);
+}
+
+bool sampler::loadUserConfiguration(const fs::path &configFile) {
+            
+    return conf->load(configFile);
+    
+}
+
+bool sampler::saveUserConfiguration(const fs::path &configFile) { 
+    return conf->save(configFile); 
 }
 
 bool sampler::zone_exist(int id)

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -83,6 +83,9 @@ class sampler
     sampler(EditorClass *editor, int NumOutputs, WrapperClass *effect = 0, SC3::Log::LoggingCallback *cb=0);
     virtual ~sampler(void);
 
+    bool loadUserConfiguration(const fs::path &configFile);
+    bool saveUserConfiguration(const fs::path &configFile);
+
     /*
      * Midi Messages
      */

--- a/tests/lowlevel_io.cpp
+++ b/tests/lowlevel_io.cpp
@@ -48,8 +48,8 @@ TEST_CASE("RIFF_MemFile", "[io]")
         SC3::Memfile::RIFFMemFile rmf(data, length);
 
         size_t chunksize;
-        int tag, LISTtag;
-        bool IsLIST;
+        int tag; //, LISTtag;
+        //bool IsLIST;
 
         std::map<std::string,int> knownSizes;
         knownSizes["fmt "] = 16;

--- a/wrappers/juce/SC3Editor.h
+++ b/wrappers/juce/SC3Editor.h
@@ -50,7 +50,7 @@ template <typename T, int qSize = 4096> class SC3EngineToWrapperQueue
     juce::AbstractFifo af;
     T dq[qSize];
 };
-class SC3IdleTimer;
+struct SC3IdleTimer;
 class SC3AudioProcessorEditor;
 
 /*

--- a/wrappers/juce/SC3Processor.cpp
+++ b/wrappers/juce/SC3Processor.cpp
@@ -14,15 +14,38 @@ void *hInstance = 0;
 
 //==============================================================================
 SC3AudioProcessor::SC3AudioProcessor()
-    : AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)),
+    : mLogger(this), AudioProcessor(BusesProperties().withOutput("Output", juce::AudioChannelSet::stereo(), true)),
       blockPos(0)
 {
     // This is a good place for VS mem leak debugging:
     // _CrtSetBreakAlloc(<id>);
+
+    // determine where config file should be stored
+    auto configLoc=juce::File::getSpecialLocation(juce::File::SpecialLocationType::userApplicationDataDirectory).getFullPathName();
+    fs::path configFile(string_to_path(static_cast<const char*>(configLoc.toUTF8())));
+    configFile.append(SC3_CONFIG_DIRECTORY);
+    configFile.append("config.xml");
+    mConfigFileName = configFile;
+    
     sc3 = std::make_unique<sampler>(nullptr, 2, nullptr, this);
+    if (!sc3->loadUserConfiguration(mConfigFileName))
+    {
+        LOGINFO(mLogger) << "Configuration file did not load" << std::flush;
+    }
+
 }
 
-SC3AudioProcessor::~SC3AudioProcessor() {
+SC3AudioProcessor::~SC3AudioProcessor()
+{
+    // save config so it's recalled next time they load
+    if (sc3)
+    {
+        if (!sc3->saveUserConfiguration(mConfigFileName))
+        {
+            // not that anyone will probably see it, but...
+            LOGINFO(mLogger) << "Configuration file did not save" << std::flush;
+        }
+    }
 }
 
 //==============================================================================

--- a/wrappers/juce/SC3Processor.h
+++ b/wrappers/juce/SC3Processor.h
@@ -22,7 +22,8 @@ class LogDisplayListener
  */
 class SC3AudioProcessor : public juce::AudioProcessor, public SC3::Log::LoggingCallback
 {
-  
+    SC3::Log::StreamLogger mLogger; 
+    fs::path mConfigFileName;
   public:
     //==============================================================================
     SC3AudioProcessor();


### PR DESCRIPTION
This allows the wrapper to provide the config file location and specify when it should be loaded and saved.