### PR TITLE
Restore SF2 load; fix up some graphics and drop cases

### DIFF
--- a/src/loaders/sampler_fileio.cpp
+++ b/src/loaders/sampler_fileio.cpp
@@ -68,6 +68,30 @@ const int ff_revision = 10;
         return false;
 }*/
 
+bool sampler::is_multisample_file(const fs::path &file_name)
+{
+    fs::path validFileName;
+    int programid = 0;
+    int sampleid = 0;
+    std::string extension, nameOnly;
+    fs::path pathOnly;
+
+    decode_path(file_name, &validFileName, &extension, &nameOnly, &pathOnly, &programid, &sampleid);
+    return is_mutlisample_extension(extension);
+}
+
+bool sampler::is_mutlisample_extension(const std::string &extension)
+{
+    if ((!extension.compare("wav")) || (!extension.compare("aif")) ||
+        (!extension.compare("aiff")) || (!extension.compare("rcy")) ||
+        (!extension.compare("rex")) || (!extension.compare("rx2")))
+    {
+        return false;
+    }
+
+    return true;
+}
+
 bool sampler::load_file(const fs::path &file_name, int *new_g, int *new_z, bool *is_group, char channel,
                         int add_zones_to_groupid, bool replace)
 {
@@ -82,9 +106,7 @@ bool sampler::load_file(const fs::path &file_name, int *new_g, int *new_z, bool 
 
     decode_path(file_name, &validFileName, &extension, &nameOnly, &pathOnly, &programid, &sampleid );
 
-    if ((!extension.compare("wav")) || (!extension.compare("aif")) ||
-        (!extension.compare("aiff")) || (!extension.compare("rcy")) ||
-        (!extension.compare("rex")) || (!extension.compare("rx2")))
+    if (!is_mutlisample_extension(extension))
     {
         if (is_group)
             *is_group = false;

--- a/src/sampler.h
+++ b/src/sampler.h
@@ -188,6 +188,8 @@ class sampler
     bool is_key_down(int channel, int key);
 
     // File I/O
+    bool is_multisample_file(const fs::path &filename);
+    bool is_mutlisample_extension(const std::string &extension);
     bool load_akai_s6k_program(const fs::path &filename, char channel = 0, bool replace = true);
     bool parse_dls_preset(void *data, size_t datasize, char channel, int patch, const char *filename);
     bool load_sf2_preset(const fs::path &filename, int *new_g = 0, char channel = 0, int patch = -1);

--- a/src/sampler_wrapper_interaction.cpp
+++ b/src/sampler_wrapper_interaction.cpp
@@ -133,9 +133,19 @@ void sampler::processWrapperEvents()
             int nz = -1;
             for (auto f : dl->files)
             {
-                if (add_zone(f.p, &nz, editorpart & 0xf, false))
+                if (is_multisample_file(f.p))
                 {
-                    LOGDEBUG(mLogger) << "Added zone; do rest of mapping too" << std::endl;
+                    if (!load_file(f.p, nullptr, &nz))
+                    {
+                        LOGDEBUG(mLogger) << "Did a loadFile for multi. What to do here?";
+                    }
+                }
+                else
+                {
+                    if (add_zone(f.p, &nz, editorpart & 0xf, false))
+                    {
+                        LOGDEBUG(mLogger) << "Added zone; do rest of mapping from below";
+                    }
                 }
             }
             if (nz != -1)

--- a/wrappers/juce/SC3Editor.cpp
+++ b/wrappers/juce/SC3Editor.cpp
@@ -157,6 +157,7 @@ void SC3AudioProcessorEditor::idle()
 
 #if DEBUG_UNHANDLED_MESSAGES
     std::map<int, std::map<int, int>> unhandled;
+    bool collapseSubtypes = true;
 #endif
     while (actiondataToUI->pop(ad))
     {
@@ -171,7 +172,10 @@ void SC3AudioProcessorEditor::idle()
         {
             // if (unhandled.find(ad.actiontype) == unhandled.end())
             //    unhandled[ad.actiontype];
-            unhandled[ad.actiontype][ad.id]++;
+            int aid = ad.id;
+            if (collapseSubtypes)
+                aid = -1;
+            unhandled[ad.actiontype][aid]++;
         }
 #endif
     }
@@ -196,8 +200,10 @@ void SC3AudioProcessorEditor::idle()
         for (auto uhsub : uh.second)
         {
             std::ostringstream oss;
-            oss << "[EDITOR] ignored UI msg=" << debug_wrapper_vga_to_string(uh.first) << "/"
-                << debug_wrapper_ip_to_string(uhsub.first) << " ct=" << uhsub.second;
+            oss << "[EDITOR] ignored UI msg=" << debug_wrapper_vga_to_string(uh.first);
+            if (!collapseSubtypes)
+                oss << "/" << debug_wrapper_ip_to_string(uhsub.first);
+            oss << " ct=" << uhsub.second;
             debugWindow->panel->appendLogText(oss.str());
         }
     }

--- a/wrappers/juce/components/DebugPanel.cpp
+++ b/wrappers/juce/components/DebugPanel.cpp
@@ -20,48 +20,8 @@
 
 void DebugPanel::buttonClicked(juce::Button *b)
 {
-    if (b == loadButton.get())
-    {
-        juce::FileChooser sampleChooser(
-            "Please choose a sample file",
-            juce::File::getSpecialLocation(juce::File::userHomeDirectory));
-        if (sampleChooser.browseForFileToOpen())
-        {
-            auto d = new DropList();
-
-            auto f = sampleChooser.getResult();
-            auto fd = DropList::File();
-            fd.p = string_to_path(f.getFileName().toStdString().c_str());
-            d->files.push_back(fd);
-
-            actiondata ad;
-            ad.actiontype = vga_load_dropfiles;
-            ad.data.dropList = d;
-            ed->sendActionToEngine(ad);
-        }
-    }
 }
 
 void DebugPanel::buttonStateChanged(juce::Button *b)
 {
-    if (b == manualButton.get())
-    {
-        switch (manualButton->getState())
-        {
-        case juce::Button::buttonDown:
-            playingNote = std::atoi(noteNumber->getText().toRawUTF8());
-            ed->audioProcessor.sc3->PlayNote(0, playingNote, 127);
-            manualPlaying = true;
-            break;
-        case juce::Button::buttonNormal:
-            if (manualPlaying)
-            {
-                manualPlaying = false;
-                ed->audioProcessor.sc3->ReleaseNote(0, playingNote, 127);
-            }
-            break;
-        case juce::Button::buttonOver:
-            break;
-        }
-    }
 }

--- a/wrappers/juce/components/DebugPanel.h
+++ b/wrappers/juce/components/DebugPanel.h
@@ -28,32 +28,17 @@ class DebugPanel : public juce::Component, public juce::Button::Listener
   public:
     DebugPanel() : Component( "Debug Panel" ) {
         int w = 500;
-        int sH = 400;
-        int lH = 200;
+        int sH = 250;
+        int lH = 350;
         setSize( w, sH + lH );
 
-        loadButton = std::make_unique<juce::TextButton>("Load Sample");
-        loadButton->setBounds(5, 2, 100, 20);
-        loadButton->addListener(this);
-        addAndMakeVisible(loadButton.get());
-
-        manualButton = std::make_unique<juce::TextButton>("Play note");
-        manualButton->setBounds(110, 2, 100, 20);
-        manualButton->addListener(this);
-        addAndMakeVisible(manualButton.get());
-
-        noteNumber = std::make_unique<juce::TextEditor>("number");
-        noteNumber->setText(std::to_string(playingNote));
-        noteNumber->setBounds(215, 2, 60, 20);
-        addAndMakeVisible(noteNumber.get());
-
         samplerT = std::make_unique<juce::TextEditor>();
-        samplerT->setBounds(5, 25, w - 10, sH - 30);
+        samplerT->setBounds(5, 5, w - 10, sH - 10);
         samplerT->setMultiLine(true, false );
         addAndMakeVisible(samplerT.get());
 
         logT = std::make_unique<juce::TextEditor>();
-        logT->setBounds(5, 5 + sH, w - 10, lH - 30);
+        logT->setBounds(5, 5 + sH, w - 10, lH - 10);
         logT->setMultiLine(true, false);
         addAndMakeVisible(logT.get());
     }
@@ -78,12 +63,6 @@ class DebugPanel : public juce::Component, public juce::Button::Listener
 
     std::unique_ptr<juce::TextEditor> samplerT;
     std::unique_ptr<juce::TextEditor> logT;
-
-    std::unique_ptr<juce::Button> loadButton;
-    std::unique_ptr<juce::Button> manualButton;
-    std::unique_ptr<juce::TextEditor> noteNumber;
-    bool manualPlaying = false;
-    int playingNote = 60;
 
     SC3AudioProcessorEditor *ed;
 };

--- a/wrappers/juce/components/ZoneKeyboardDisplay.cpp
+++ b/wrappers/juce/components/ZoneKeyboardDisplay.cpp
@@ -39,6 +39,8 @@ void ZoneKeyboardDisplay::paint(juce::Graphics &g)
     // end configuration
 
     g.fillAll(juce::Colour(80, 70, 60));
+    g.setColour(juce::Colour(255, 255, 255));
+    g.drawText("Drop Samples Here or Double Click to Load", getBounds(), Justification::centred);
     g.setColour(juce::Colour(0, 0, 0));
 
     /*
@@ -179,5 +181,24 @@ void ZoneKeyboardDisplay::mouseUp(const MouseEvent &event)
         sender->sendActionToEngine(ad);
 
         playingKey = -1;
+    }
+}
+void ZoneKeyboardDisplay::mouseDoubleClick(const MouseEvent &event)
+{
+    juce::FileChooser sampleChooser("Please choose a sample file",
+                                    juce::File::getSpecialLocation(juce::File::userHomeDirectory));
+    if (sampleChooser.browseForFileToOpen())
+    {
+        auto d = new DropList();
+
+        auto f = sampleChooser.getResult();
+        auto fd = DropList::File();
+        fd.p = string_to_path(f.getFullPathName().toStdString().c_str());
+        d->files.push_back(fd);
+
+        actiondata ad;
+        ad.actiontype = vga_load_dropfiles;
+        ad.data.dropList = d;
+        sender->sendActionToEngine(ad);
     }
 }

--- a/wrappers/juce/components/ZoneKeyboardDisplay.h
+++ b/wrappers/juce/components/ZoneKeyboardDisplay.h
@@ -34,6 +34,8 @@ class ZoneKeyboardDisplay : public juce::Component
     void mouseDown(const MouseEvent &event) override;
     void mouseUp(const MouseEvent &event) override;
 
+    void mouseDoubleClick(const MouseEvent &event) override;
+
   private:
     std::vector<juce::Rectangle<float>> keyLocations;
     ZoneStateProxy *zsp; // a non-owned weak copy


### PR DESCRIPTION
1. SF2 and other multi-sample load via drop works again
2. Turn off the most detailed message logging restoring performance
3. Remove the now uneeded load-file and play-note buttons
4. Make double click open a load sequence